### PR TITLE
Fix webworker leak from ace

### DIFF
--- a/src/components/Result/Result.js
+++ b/src/components/Result/Result.js
@@ -17,16 +17,23 @@ export const ResultTable = ({ id, queryTask }) => {
             }
             return (
                 <div>
-                    <pre>
-                        {`got ${results.length} result${results.length === 1
-                            ? ""
-                            : "s"} in ${queryTask.finish - queryTask.start}ms`}
-                    </pre>
+                    <ResultDescription {...queryTask} />
                     {results.length && <Table keys={keys} rows={rows} />}
                 </div>
             );
         }
     });
+};
+
+export const ResultDescription = ({ result, start, finish }) => {
+    if (!(result && start && finish)) {
+        return null;
+    }
+    return (
+        <pre>
+            {`got ${result.length} result${result.length === 1 ? "" : "s"} in ${finish - start}ms`}
+        </pre>
+    );
 };
 
 const mstp = (state, { id }) => {

--- a/src/components/Result/index.js
+++ b/src/components/Result/index.js
@@ -1,3 +1,3 @@
-import Result, { ResultTable } from "./Result";
-export { ResultTable };
+import Result, { ResultTable, ResultDescription } from "./Result";
+export { ResultTable, ResultDescription };
 export default Result;

--- a/src/components/SchemaExplorer/index.js
+++ b/src/components/SchemaExplorer/index.js
@@ -1,3 +1,7 @@
-import SchemaExplorer, { SchemaDropdown, schemaData } from "./SchemaExplorer";
-export { SchemaDropdown, schemaData };
+import SchemaExplorer, {
+    SchemaDropdown,
+    schemaData,
+    schemaTypes
+} from "./SchemaExplorer";
+export { SchemaDropdown, schemaData, schemaTypes };
 export default SchemaExplorer;

--- a/src/utils/parse-user-query.js
+++ b/src/utils/parse-user-query.js
@@ -5,6 +5,8 @@ export function parseUserQueryEval(raw) {
         const len = userQuery.length;
         if (raw[0] === "{" && raw[len - 1] === "}") {
             try {
+                // We know eval is bad. We try to use a worker if possible
+                // eslint-disable-next-line no-eval
                 eval("parsedUserQuery = " + userQuery);
             } catch (err) {
                 reject(err);


### PR DESCRIPTION
The editor was not `destroy()`'d on unmount, leaving orphaned worker threads.
Fixed up the ORM to use routing, e.g. `/orm/person`
Fixed `parse-user-query` eval lint warning